### PR TITLE
Fix libigl compile error by adding libxrandr-dev dependency

### DIFF
--- a/products/salome_system.pyconf
+++ b/products/salome_system.pyconf
@@ -19,7 +19,8 @@ default :
         rpm_dev : ["openssl-devel", "tbb-devel", "gcc", "make", "sed", "gcc-c++", "expat-devel", "fontconfig-devel", "flex",
                    "bison", "mesa-libGLU-devel", "libxcb-devel", "xcb-util-devel", "libxkbcommon-devel", "libxkbcommon-x11-devel",
                    "bzip2-devel", "libXi-devel", "libXmu-devel", "automake", "libtool", "libjpeg-turbo-devel", "cmake",
-                   "libXpm-devel", "libXft-devel", "sqlite-devel", "libcurl-devel", "libXt-devel", "libXcursor-devel", "tbb-devel", "libXinerama-devel"]
+                   "libXpm-devel", "libXft-devel", "sqlite-devel", "libcurl-devel", "libXt-devel", "libXcursor-devel", "tbb-devel",
+                   "libXinerama-devel", "libXrandr-devel"]
         apt : ["libbsd0", "libbz2-1.0", "libc6", "libdrm2", "libegl1", "libexif12", "libexpat1",
                "libfftw3-double3", "libfontconfig1", "libgl1", "libglu1-mesa", "libgomp1", "libgphoto2-6", "libice6",
                "libjbig0", "libltdl7", "liblzma5", "libnuma1", "libquadmath0",
@@ -31,7 +32,7 @@ default :
                    "libglu1-mesa-dev", "perl", "libxcb-dri2-0-dev", "libxkbcommon-dev", "libxkbcommon-x11-dev", "bzip2",
                    "libxi-dev", "libxt-dev", "libxmu-dev", "libxpm-dev", "libxft-dev", "automake", "libtool", "libjpeg-dev",
                    "cmake", "libicu-dev", "libopenmpi-dev", "libreadline-dev", "libhwloc-dev", "libsqlite3-dev", "libcurl4-openssl-dev",
-                   "libxt-dev", "libxcursor-dev", "libtbb-dev"]
+                   "libxt-dev", "libxcursor-dev", "libtbb-dev", "libxrandr-dev"]
 
         # specific to some platform(s)
         "CO7" :


### PR DESCRIPTION
This resolves the "RandR headers not found; install libxrandr development package" error encountered 
during libigl module compilation.