### PR TITLE
Cork requires clang compiler and unrestricted SHELL!=/bin/sh to comple Triangle library

### DIFF
--- a/products/compil_scripts/cork.sh
+++ b/products/compil_scripts/cork.sh
@@ -10,7 +10,7 @@ cd $BUILD_DIR
 cp -r $SOURCE_DIR/* .
 echo
 echo "*** make" $MAKE_OPTIONS
-make $MAKE_OPTIONS
+make SHELL=/bin/bash $MAKE_OPTIONS
 if [ $? -ne 0 ]; then
     echo "ERROR on make"
     exit 1

--- a/products/cork.pyconf
+++ b/products/cork.pyconf
@@ -28,7 +28,7 @@ default :
               "Python",
               "numpy"
              ]
-    build_depend : ["cmake", "cppunit"]
+    build_depend : ["cmake", "cppunit", "llvm"]
     opt_depend : [
                   "cgal",
                   "libigl",


### PR DESCRIPTION
Triangle library requires special compile flags that are issued under default SHELL=/bin/sh which is restricted somehow on some Enterprise Linux 9 systems (symlink to /bin/bash)
The error is shown as 
`clang: premission denied`

Forcing make SHELL to /bin/bash resolves the problem.

